### PR TITLE
chore(test): update systemd unit names

### DIFF
--- a/test/integration/nixos.nix
+++ b/test/integration/nixos.nix
@@ -40,7 +40,7 @@ pkgs.testers.runNixOSTest {
       };
     };
 
-    systemd.user.services."pareto-core-hourly" = {
+    systemd.user.services."paretosecurity-hourly" = {
       wantedBy = ["timers.target"];
       serviceConfig = {
         Type = "oneshot";
@@ -49,7 +49,7 @@ pkgs.testers.runNixOSTest {
       };
     };
 
-    systemd.user.timers."pareto-core-hourly" = {
+    systemd.user.timers."paretosecurity-hourly" = {
       wantedBy = ["timers.target"];
       timerConfig = {
         OnCalendar = "hourly";


### PR DESCRIPTION
Remove old project name from nixos tests systemd service/timer unit names.

Note: these units are not actually used in the test as far as I can tell. Or maybe `Persistent=true` does that. In any case,`nixos.py` runs `paretosecurity check` directly.