### PR TITLE
Add NixOS Integration test for Screen lock

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -86,7 +86,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        check: [firewall]
+        check: [firewall, screenlock]
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/devenv

--- a/checks/linux/password_unlock.go
+++ b/checks/linux/password_unlock.go
@@ -1,7 +1,6 @@
 package checks
 
 import (
-	"os/exec"
 	"strings"
 
 	"github.com/ParetoSecurity/agent/shared"
@@ -36,20 +35,23 @@ func (f *PasswordToUnlock) checkKDE() bool {
 
 // Run executes the check
 func (f *PasswordToUnlock) Run() error {
+	anyCheckPerformed := false
+	allChecksPassed := true
+
 	// Check if running GNOME
-	if _, err := exec.LookPath("gsettings"); err == nil {
-		f.passed = f.checkGnome()
-		return nil
+	if _, err := lookPath("gsettings"); err == nil {
+		anyCheckPerformed = true
+		allChecksPassed = allChecksPassed && f.checkGnome()
 	}
 
 	// Check if running KDE
-	if _, err := exec.LookPath("kreadconfig5"); err == nil {
-		f.passed = f.checkKDE()
-		return nil
+	if _, err := lookPath("kreadconfig5"); err == nil {
+		anyCheckPerformed = true
+		allChecksPassed = allChecksPassed && f.checkKDE()
 	}
 
-	// Neither GNOME nor KDE found
-	f.passed = false
+	// Performed at least one check and all performed checks passed
+	f.passed = anyCheckPerformed && allChecksPassed
 	return nil
 }
 

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,8 @@
 
         checks.firewall = pkgs.testers.runNixOSTest ./test/integration/firewall.nix;
 
+        checks.screenlock = pkgs.testers.runNixOSTest ./test/integration/screenlock.nix;
+
         packages.test-debian = testPackage {
           distro = "debian";
           version = "13";

--- a/test/integration/common.nix
+++ b/test/integration/common.nix
@@ -1,0 +1,32 @@
+{
+  # Override paretosecurity to use the local codebase
+  pareto = {
+    pkgs,
+    lib,
+    ...
+  }: {
+    services.paretosecurity = {
+      enable = true;
+      package = pkgs.callPackage ../../package.nix {inherit lib;};
+    };
+  };
+
+  # Easier tests debugging by SSH-ing into nodes
+  ssh = {port}: {...}: {
+    services.openssh = {
+      enable = true;
+      settings = {
+        PermitRootLogin = "yes";
+        PermitEmptyPasswords = "yes";
+      };
+    };
+    security.pam.services.sshd.allowNullPassword = true;
+    virtualisation.forwardPorts = [
+      {
+        from = "host";
+        host.port = port;
+        guest.port = 22;
+      }
+    ];
+  };
+}

--- a/test/integration/screenlock.nix
+++ b/test/integration/screenlock.nix
@@ -1,0 +1,85 @@
+let
+  common = import ./common.nix;
+  inherit (common) pareto ssh;
+in {
+  name = "Check test: screensaver password";
+
+  nodes = {
+    gnome = {
+      pkgs,
+      lib,
+      ...
+    }: {
+      imports = [
+        (pareto {inherit pkgs lib;})
+      ];
+      # Install GNOME Desktop Environment
+      services.xserver.desktopManager.gnome.enable = true;
+      services.xserver.displayManager.gdm.enable = true;
+    };
+
+    kde = {
+      pkgs,
+      lib,
+      ...
+    }: {
+      imports = [
+        (pareto {inherit pkgs lib;})
+      ];
+      # Install KDE Plasma 5 Desktop Environment
+      services.xserver.enable = true;
+      services.xserver.desktopManager.plasma5.enable = true;
+      services.xserver.displayManager.sddm.enable = true;
+      services.colord.enable = false;
+    };
+  };
+
+  interactive.nodes.gnome = {...}:
+    ssh {port = 2221;} {};
+
+  interactive.nodes.kde = {...}:
+    ssh {port = 2222;} {};
+
+  testScript = ''
+    # Test GNOME
+    # Test 1: Check passes by default
+    out = gnome.succeed("paretosecurity check --only 37dee029-605b-4aab-96b9-5438e5aa44d8")
+    expected = (
+        "  • Starting checks...\n"
+        "  • Access Security: Password is required to unlock the screen > [OK] Password after sleep or screensaver is on\n"
+        "  • Checks completed.\n"
+    )
+    assert out == expected, f"Expected did not match actual, got \n{out}"
+
+    # Test 2: Check fails when lock is disabled
+    gnome.succeed("dbus-run-session -- gsettings set org.gnome.desktop.screensaver lock-enabled false")
+    status, out = gnome.execute("paretosecurity check --only 37dee029-605b-4aab-96b9-5438e5aa44d8")
+    expected = (
+        "  • Starting checks...\n"
+        "  • Access Security: Password is required to unlock the screen > [FAIL] Password after sleep or screensaver is off\n"
+        "  • Checks completed.\n"
+    )
+    assert out == expected, f"Expected did not match actual, got \n{out}"
+
+    # Test KDE
+    # Test 1: Check passes with lock enabled
+    kde.succeed("kwriteconfig5 --file kscreenlockerrc --group Daemon --key Autolock true")
+    out = kde.succeed("paretosecurity check --only 37dee029-605b-4aab-96b9-5438e5aa44d8")
+    expected = (
+        "  • Starting checks...\n"
+        "  • Access Security: Password is required to unlock the screen > [OK] Password after sleep or screensaver is on\n"
+        "  • Checks completed.\n"
+    )
+    assert out == expected, f"Expected did not match actual, got \n{out}"
+
+    # Test 2: Check fails when lock is disabled
+    kde.succeed("kwriteconfig5 --file kscreenlockerrc --group Daemon --key Autolock false")
+    status, out = kde.execute("paretosecurity check --only 37dee029-605b-4aab-96b9-5438e5aa44d8")
+    expected = (
+        "  • Starting checks...\n"
+        "  • Access Security: Password is required to unlock the screen > [FAIL] Password after sleep or screensaver is off\n"
+        "  • Checks completed.\n"
+    )
+    assert out == expected, f"Expected did not match actual, got \n{out}"
+  '';
+}


### PR DESCRIPTION
- Make Screen lock check verify all installed desktop environments that are supported - (e.g. user has both GNOME and KDE installed so both should be verified).
- Add integration tests for Screen lock.

Ref: https://github.com/teamniteo/pareto/issues/643