### PR TITLE
cleanup: Upgrade nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1741352980,
-        "narHash": "sha256-+u2UunDA4Cl5Fci3m7S643HzKmIDAe+fiXrLqYsR2fs=",
+        "lastModified": 1743550720,
+        "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f4330d22f1c5d2ba72d3d22df5597d123fdb60a9",
+        "rev": "c621e8422220273271f52058f618c94e405bb0f5",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1742198803,
-        "narHash": "sha256-/SYooyWkU/Ib9M3aes9ZU/QZS5aw93uI1jgNOxy+aM0=",
+        "lastModified": 1746458227,
+        "narHash": "sha256-T8kT73joeMXKWcw0IQcNoTcr9IF63Mcm4Bi0TpfxdJA=",
         "owner": "numtide",
         "repo": "nix-vm-test",
-        "rev": "1b00ec461fb80ace7f3f5534ae75079e1a562464",
+        "rev": "a9aba69cd05d604c4ece66780c77219714ebd91a",
         "type": "github"
       },
       "original": {
@@ -53,11 +53,11 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1740877520,
-        "narHash": "sha256-oiwv/ZK/2FhGxrCkQkB83i7GnWXPPLzoqFHpDD3uYpk=",
+        "lastModified": 1743296961,
+        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "147dee35aab2193b174e4c0868bd80ead5ce755c",
+        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
         "type": "github"
       },
       "original": {
@@ -68,16 +68,16 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1743789887,
-        "narHash": "sha256-Xj5UXgvxEIZmHUDQw9pTcXzVIeWVijRXwHyzVoa6L7Q=",
+        "lastModified": 1746397377,
+        "narHash": "sha256-5oLdRa3vWSRbuqPIFFmQBGGUqaYZBxX+GGtN9f/n4lU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f3cfb1c5ff2405d33224e79c49bea44d13f8be62",
+        "rev": "ed30f8aba41605e3ab46421e3dcb4510ec560ff8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "master",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/master";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     nix-vm-test.url = "github:numtide/nix-vm-test";
     systems.url = "github:nix-systems/default";
   };

--- a/package.nix
+++ b/package.nix
@@ -3,16 +3,16 @@
   lib,
 }: let
   nixpkgsPareto = pkgs.callPackage (pkgs.path + "/pkgs/by-name/pa/paretosecurity/package.nix") {};
+
+  # Create a fake src with rev attribute
+  srcWithRev = {
+    outPath = ./.;
+    rev = lib.substring 0 8 (builtins.hashFile "sha256" ./go.sum);
+  };
 in
   nixpkgsPareto.overrideAttrs (oldAttrs: {
-    src = ./.;
+    src = srcWithRev;
     version = "${builtins.hashFile "sha256" "${toString ./go.sum}"}";
-    subPackages = ["cmd/paretosecurity"];
-    nativeBuildInputs =
-      [
-        pkgs.pkg-config
-      ]
-      ++ oldAttrs.nativeBuildInputs;
 
     # Updated with pre-commit, don't change manually
     vendorHash = "sha256-YnyACP/hJYxi4AWMwr0We4YUTbWwahKAIYN6RnHmzls=";


### PR DESCRIPTION
So that we can get the latest package definition from nixpkgs and can remove local fixes.