### PR TITLE
feat: Add support for nftables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,7 @@ jobs:
         shell: pwsh
       - name: Install Edge WebView2 Runtime
         run: winget install -e --id Microsoft.EdgeWebView2Runtime --silent --accept-package-agreements --accept-source-agreements --disable-interactivity
+        continue-on-error: true
       - name: Run Installer
         run: |
           # Start the installer in a new process

--- a/checks/linux/firewall.go
+++ b/checks/linux/firewall.go
@@ -29,11 +29,35 @@ func (f *Firewall) checkNFTables() bool {
 	log.WithField("output", output).Debug("Nftables status")
 
 	// Check if the output contains input CHAIN
-	if strings.Contains(output, "chain INPUT") || strings.Contains(output, "chain input") {
-		return true
+	scanner := bufio.NewScanner(strings.NewReader(output))
+	inInputChain := false
+	hasDropPolicy := false
+
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		// Check if we're entering the INPUT chain definition
+		if strings.HasPrefix(line, "chain INPUT") || strings.HasPrefix(line, "chain input") {
+			inInputChain = true
+			continue
+		}
+
+		// If we're in the INPUT chain and find policy information
+		if inInputChain && strings.Contains(line, "policy") {
+			if strings.Contains(line, "policy drop") {
+				hasDropPolicy = true
+			}
+			break // We've found the policy, no need to continue
+		}
+
+		// Exit the INPUT chain section if we encounter a new chain
+		if inInputChain && strings.HasPrefix(line, "chain") && !strings.HasPrefix(line, "chain INPUT") && !strings.HasPrefix(line, "chain input") {
+			break
+		}
 	}
 
-	return false
+	return inInputChain && hasDropPolicy
+
 }
 
 // checkIptables checks if iptables is active

--- a/checks/linux/firewall.go
+++ b/checks/linux/firewall.go
@@ -26,7 +26,7 @@ func checkNFTables() bool {
 		log.WithError(err).Warn("Failed to check nftables status")
 		return false
 	}
-	log.WithField("output", output).Debug("Nftables status")
+	log.WithField("output", output).Info("Nftables status")
 
 	// Check if the output contains input CHAIN
 	if strings.Contains(output, "chain INPUT") {
@@ -43,7 +43,7 @@ func (f *Firewall) checkIptables() bool {
 		log.WithError(err).WithField("output", output).Warn("Failed to check iptables status")
 		return false
 	}
-	log.WithField("output", output).Debug("Iptables status")
+	log.WithField("output", output).Info("Iptables status")
 
 	// Define a struct to hold iptables rule information
 	type IptablesRule struct {
@@ -123,7 +123,10 @@ func (f *Firewall) checkIptables() bool {
 
 // Run executes the check
 func (f *Firewall) Run() error {
-	f.passed = f.checkIptables() || checkNFTables()
+	f.passed = f.checkIptables()
+	if !f.passed {
+		f.passed = checkNFTables()
+	}
 	return nil
 }
 

--- a/checks/linux/firewall.go
+++ b/checks/linux/firewall.go
@@ -11,8 +11,7 @@ import (
 
 // Firewall checks the system firewall.
 type Firewall struct {
-	passed  bool
-	details string
+	passed bool
 }
 
 // Name returns the name of the check
@@ -33,7 +32,7 @@ func (f *Firewall) checkNFTables() bool {
 	if strings.Contains(output, "chain INPUT") || strings.Contains(output, "chain input") {
 		return true
 	}
-	f.details = "No input chain found in nftables, ouput: " + output
+
 	return false
 }
 

--- a/checks/linux/firewall_test.go
+++ b/checks/linux/firewall_test.go
@@ -261,7 +261,7 @@ func TestCheckNFTables(t *testing.T) {
 		},
 		{
 			name:           "nixos NFTables configured without chain input",
-			mockOutput:     "table inet filter {\n\tchain input {\n\t\ttype filter hook output priority 0;\n\t\tpolicy accept;\n\t}\n}",
+			mockOutput:     "table inet filter {\n\tchain input {\n\t\ttype filter hook output priority 0;\n\t\tpolicy drop;\n\t}\n}",
 			mockError:      nil,
 			expectedResult: true,
 		},

--- a/checks/linux/firewall_test.go
+++ b/checks/linux/firewall_test.go
@@ -260,7 +260,7 @@ func TestCheckNFTables(t *testing.T) {
 			expectedResult: false,
 		},
 		{
-			name:           "nixos NFTables configured with chain input",
+			name:           "nixos NFTables configured with lowercase chain input",
 			mockOutput:     "table inet filter {\n\tchain input {\n\t\ttype filter hook input priority 0;\n\t\tpolicy drop;\n\t}\n}",
 			mockError:      nil,
 			expectedResult: true,

--- a/checks/linux/firewall_test.go
+++ b/checks/linux/firewall_test.go
@@ -260,7 +260,7 @@ func TestCheckNFTables(t *testing.T) {
 			expectedResult: false,
 		},
 		{
-			name:           "nixos NFTables configured without chain input",
+			name:           "nixos NFTables configured with chain input",
 			mockOutput:     "table inet filter {\n\tchain input {\n\t\ttype filter hook output priority 0;\n\t\tpolicy drop;\n\t}\n}",
 			mockError:      nil,
 			expectedResult: true,

--- a/checks/linux/firewall_test.go
+++ b/checks/linux/firewall_test.go
@@ -261,7 +261,7 @@ func TestCheckNFTables(t *testing.T) {
 		},
 		{
 			name:           "nixos NFTables configured with chain input",
-			mockOutput:     "table inet filter {\n\tchain input {\n\t\ttype filter hook output priority 0;\n\t\tpolicy drop;\n\t}\n}",
+			mockOutput:     "table inet filter {\n\tchain input {\n\t\ttype filter hook input priority 0;\n\t\tpolicy drop;\n\t}\n}",
 			mockError:      nil,
 			expectedResult: true,
 		},

--- a/checks/linux/firewall_test.go
+++ b/checks/linux/firewall_test.go
@@ -234,9 +234,8 @@ num  target     prot opt source               destination
 				"iptables -L INPUT --line-numbers": tt.mockOutput,
 			})
 			f := &Firewall{}
-			err := f.Run()
-			assert.NoError(t, err)
-			assert.Equal(t, tt.expectedPassed, f.Passed())
+			result := f.checkIptables()
+			assert.Equal(t, tt.expectedPassed, result)
 		})
 	}
 }
@@ -259,6 +258,12 @@ func TestCheckNFTables(t *testing.T) {
 			mockOutput:     "table inet filter {\n\tchain OUTPUT {\n\t\ttype filter hook output priority 0;\n\t\tpolicy accept;\n\t}\n}",
 			mockError:      nil,
 			expectedResult: false,
+		},
+		{
+			name:           "nixos NFTables configured without chain input",
+			mockOutput:     "table inet filter {\n\tchain input {\n\t\ttype filter hook output priority 0;\n\t\tpolicy accept;\n\t}\n}",
+			mockError:      nil,
+			expectedResult: true,
 		},
 		{
 			name:           "NFTables command error",
@@ -285,8 +290,8 @@ func TestCheckNFTables(t *testing.T) {
 					Err:     tt.mockError,
 				},
 			}
-
-			result := checkNFTables()
+			f := &Firewall{}
+			result := f.checkNFTables()
 			assert.Equal(t, tt.expectedResult, result)
 		})
 	}

--- a/test/integration/firewall.nix
+++ b/test/integration/firewall.nix
@@ -52,7 +52,6 @@ in {
       ];
       networking.nftables.enable = true;
     };
-
   };
 
   interactive.nodes.wideopen = {...}:

--- a/test/integration/firewall.nix
+++ b/test/integration/firewall.nix
@@ -29,7 +29,7 @@ in {
       networking.firewall.enable = false;
     };
 
-    walled = {
+    iptables = {
       pkgs,
       lib,
       ...
@@ -40,26 +40,43 @@ in {
       ];
       networking.firewall.enable = true;
     };
+
+    nftables = {
+      pkgs,
+      lib,
+      ...
+    }: {
+      imports = [
+        (pareto {inherit pkgs lib;})
+        (nginx {inherit pkgs;})
+      ];
+      networking.nftables.enable = true;
+    };
+
   };
 
   interactive.nodes.wideopen = {...}:
     ssh {port = 2221;} {};
 
-  interactive.nodes.walled = {...}:
+  interactive.nodes.iptables = {...}:
+    ssh {port = 2222;} {};
+
+  interactive.nodes.nftables = {...}:
     ssh {port = 2222;} {};
 
   testScript = ''
     # Test Setup
-    for m in [wideopen, walled]:
+    for m in [wideopen, iptables, nftables]:
       m.systemctl("start network-online.target")
       m.wait_for_unit("network-online.target")
       m.wait_for_unit("nginx")
 
     # Test 0: assert firewall is actually configured
-    wideopen.fail("curl --fail --connect-timeout 2 http://walled")
-    walled.succeed("curl --fail --connect-timeout 2 http://wideopen")
+    wideopen.fail("curl --fail --connect-timeout 2 http://iptables")
+    wideopen.fail("curl --fail --connect-timeout 2 http://nftables")
+    iptables.succeed("curl --fail --connect-timeout 2 http://wideopen")
 
-    # Test 1: check fails with iptables disabled
+    # Test 1: check fails with no firewall enabled
     out = wideopen.fail("paretosecurity check --only 2e46c89a-5461-4865-a92e-3b799c12034a")
     expected = (
         "  • Starting checks...\n"
@@ -69,7 +86,16 @@ in {
     assert out == expected, f"{expected} did not match actual, got \n{out}"
 
     # Test 2: check succeeds with iptables enabled
-    out = walled.succeed("paretosecurity check --only 2e46c89a-5461-4865-a92e-3b799c12034a")
+    out = iptables.succeed("paretosecurity check --only 2e46c89a-5461-4865-a92e-3b799c12034a")
+    expected = (
+        "  • Starting checks...\n"
+        "  • [root] Firewall & Sharing: Firewall is configured > [OK] Firewall is on\n"
+        "  • Checks completed.\n"
+    )
+    assert out == expected, f"{expected} did not match actual, got \n{out}"
+
+    # Test 3: check succeeds with nftables enabled
+    out = nftables.succeed("paretosecurity check --only 2e46c89a-5461-4865-a92e-3b799c12034a")
     expected = (
         "  • Starting checks...\n"
         "  • [root] Firewall & Sharing: Firewall is configured > [OK] Firewall is on\n"


### PR DESCRIPTION
As of recently, many firewall frontends have moved to using nftables instead of iptables. This commit adds support for detecting if nftables are used as a fiewall implementation.

Refs https://github.com/ParetoSecurity/agent/issues/39