### PR TITLE
feat: Add support for gnome-keyring password manager

### DIFF
--- a/checks/linux/password_manager.go
+++ b/checks/linux/password_manager.go
@@ -18,7 +18,7 @@ func (pmc *PasswordManagerCheck) Name() string {
 }
 
 func (pmc *PasswordManagerCheck) isManagerInstalled() bool {
-	passwordManagers := []string{"1password", "bitwarden", "dashlane", "keepassx", "keepassxc"}
+	passwordManagers := []string{"1password", "bitwarden", "dashlane", "keepassx", "keepassxc", "gnome-keyring"}
 
 	for _, pwdManager := range passwordManagers {
 		if isPackageInstalled(pwdManager) {

--- a/checks/linux/password_manager_test.go
+++ b/checks/linux/password_manager_test.go
@@ -57,6 +57,34 @@ func TestPasswordManagerCheck_Run_Linux(t *testing.T) {
 			expectedStatus: "Password manager is present",
 		},
 		{
+			name: "gnome-keyring found in PATH",
+			mockCommands: map[string]string{
+				"which gnome-keyring": "/usr/bin/gnome-keyring",
+			},
+			expectedPassed: true,
+			expectedStatus: "Password manager is present",
+		},
+		{
+			name: "gnome-keyring present via apt",
+			mockCommands: map[string]string{
+				"which 1password":     "not found",
+				"which bitwarden":     "not found",
+				"which dashlane":      "not found",
+				"which keepassx":      "not found",
+				"which keepassxc":     "not found",
+				"which gnome-keyring": "not found",
+				"which dpkg":          "/usr/bin/dpkg",
+				"sh -c dpkg -l":       "ii  gnome-keyring  1.0  all  Password manager",
+				"which snap":          "not found",
+				"which yum":           "not found",
+				"which flatpak":       "not found",
+				"which pacman":        "not found",
+				"which nix-store":     "not found",
+			},
+			expectedPassed: true,
+			expectedStatus: "Password manager is present",
+		},
+		{
 			name: "1Password present via apt",
 			mockCommands: map[string]string{
 				"which 1password": "not found",


### PR DESCRIPTION
It would be better to detect usage of  `org.freedesktop.secrets` so that the check has a more generic password manager detection, but let's not let perfect be the enemy of good and do the refactor at a later point: https://github.com/teamniteo/pareto/issues/712

cc @domenkozar