### PR TITLE
feat: refactor KDE check logic to read configuration file directly

### DIFF
--- a/shared/home.go
+++ b/shared/home.go
@@ -1,0 +1,26 @@
+package shared
+
+import (
+	"os"
+	"testing"
+)
+
+// UserHomeDir returns the current user's home directory.
+//
+// On Unix, including macOS, it returns the $HOME environment variable.
+// On Windows, it returns %USERPROFILE%.
+// On Plan 9, it returns the $home environment variable.
+//
+// If the expected variable is not set in the environment, UserHomeDir
+// returns either a platform-specific default value or a non-nil error.
+func UserHomeDir() (string, error) {
+	if testing.Testing() {
+		// In tests, return a mock home directory
+		return "/home/user", nil
+	}
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return homeDir, nil
+}

--- a/test/integration/screenlock.nix
+++ b/test/integration/screenlock.nix
@@ -63,7 +63,7 @@ in {
 
     # Test KDE
     # Test 1: Check passes with lock enabled
-    kde.succeed("kwriteconfig5 --file kscreenlockerrc --group Daemon --key Autolock true")
+    kde.succeed("kwriteconfig5 --file kscreenlockerrc --group Daemon --key LockOnResume true")
     out = kde.succeed("paretosecurity check --only 37dee029-605b-4aab-96b9-5438e5aa44d8")
     expected = (
         "  • Starting checks...\n"
@@ -73,7 +73,7 @@ in {
     assert out == expected, f"Expected did not match actual, got \n{out}"
 
     # Test 2: Check fails when lock is disabled
-    kde.succeed("kwriteconfig5 --file kscreenlockerrc --group Daemon --key Autolock false")
+    kde.succeed("kwriteconfig5 --file kscreenlockerrc --group Daemon --key LockOnResume false")
     status, out = kde.execute("paretosecurity check --only 37dee029-605b-4aab-96b9-5438e5aa44d8")
     expected = (
         "  • Starting checks...\n"


### PR DESCRIPTION
KDE has very dubious command-line usage, where "--default" defaults to whatever is specified, and not the actual configured value. This is because some states are defaulted in runtime but never persisted in files. With this patch we test for absence of configuration that would turn off the screen lock on resume.


ref: https://github.com/ParetoSecurity/agent/issues/129