### PR TITLE
refactor: Remove nix-vm-test dependency and related code from flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1749398372,
-        "narHash": "sha256-tYBdgS56eXYaWVW3fsnPQ/nFlgWi/Z2Ymhyu21zVM98=",
+        "lastModified": 1751413152,
+        "narHash": "sha256-Tyw1RjYEsp5scoigs1384gIg6e0GoBVjms4aXFfRssQ=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "9305fe4e5c2a6fcf5ba6a3ff155720fbe4076569",
+        "rev": "77826244401ea9de6e3bac47c2db46005e1f30b5",
         "type": "github"
       },
       "original": {
@@ -17,62 +17,13 @@
         "type": "indirect"
       }
     },
-    "nix-vm-test": {
-      "inputs": {
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1748241170,
-        "narHash": "sha256-uloGXUZdjTmrLpTKbFetLzNhmKO1ySQdEDiLTFB+4i8=",
-        "owner": "numtide",
-        "repo": "nix-vm-test",
-        "rev": "2440f3ab2e131515253777b0d27b66c0357f299b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "nix-vm-test",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1708475490,
-        "narHash": "sha256-g1v0TsWBQPX97ziznfJdWhgMyMGtoBFs102xSYO4syU=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "0e74ca98a74bc7270d28838369593635a5db3260",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib": {
-      "locked": {
-        "lastModified": 1748740939,
-        "narHash": "sha256-rQaysilft1aVMwF14xIdGS3sj1yHlI6oKQNBRTF40cc=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "656a64127e9d791a334452c6b6606d17539476e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1751180975,
-        "narHash": "sha256-BKk4yDiXr4LdF80OTVqYJ53Q74rOcA/82EClXug8xsY=",
+        "lastModified": 1751949589,
+        "narHash": "sha256-mgFxAPLWw0Kq+C8P3dRrZrOYEQXOtKuYVlo9xvPntt8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a48741b083d4f36dd79abd9f760c84da6b4dc0e5",
+        "rev": "9b008d60392981ad674e04016d25619281550a9d",
         "type": "github"
       },
       "original": {
@@ -82,11 +33,25 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1751159883,
+        "narHash": "sha256-urW/Ylk9FIfvXfliA1ywh75yszAbiTEVgpPeinFyVZo=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "14a40a1d7fb9afa4739275ac642ed7301a9ba1ab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
-        "nix-vm-test": "nix-vm-test",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,13 +1,11 @@
 {
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    nix-vm-test.url = "github:numtide/nix-vm-test";
   };
 
   outputs = inputs @ {
     flake-parts,
     nixpkgs,
-    nix-vm-test,
     self,
     ...
   }:
@@ -22,30 +20,7 @@
         system,
         ...
       }: let
-        flakePackage = import ./package.nix {inherit pkgs lib;};
-        testPackage = {
-          distro,
-          version,
-          script,
-        }:
-          (inputs.nix-vm-test.lib.x86_64-linux.${distro}.${version} {
-            sharedDirs.packageDir = {
-              source = "${toString ./.}/pkg";
-              target = "/mnt/package";
-            };
-            testScript = builtins.readFile "${toString ./.}/test/integration/${script}";
-          })
-          .driver;
-        testRelease = {
-          distro,
-          version,
-          script,
-        }:
-          (inputs.nix-vm-test.lib.x86_64-linux.${distro}.${version} {
-            sharedDirs = {};
-            testScript = builtins.readFile "${toString ./.}/test/integration/${script}";
-          })
-          .driver;
+        flakePackage = pkgs.callPackage ./package.nix {};
       in {
         packages.default = flakePackage;
 


### PR DESCRIPTION
Nix-vm was replaced by incus and docker tests.