### PR TITLE
feat: Add single instance lock for tray applications

### DIFF
--- a/cmd/paretosecurity-tray/main.go
+++ b/cmd/paretosecurity-tray/main.go
@@ -3,7 +3,19 @@
 
 package main
 
+import (
+	"github.com/allan-simon/go-singleinstance"
+	"github.com/caarlos0/log"
+)
+
 func main() {
+	lockFile, err := singleinstance.CreateLockFile("paretosecurity-tray.lock")
+	if err != nil {
+		log.WithError(err).Fatal("An instance of ParetoSecurity tray application is already running.")
+		return
+	}
+	defer lockFile.Close()
+
 	app := NewTrayApp(nil)
 	app.Run()
 }

--- a/cmd/paretosecurity/main.go
+++ b/cmd/paretosecurity/main.go
@@ -2,6 +2,7 @@
 package main
 
 func main() {
+
 	app := NewApp(nil)
 	app.Run()
 }

--- a/cmd/trayicon.go
+++ b/cmd/trayicon.go
@@ -13,6 +13,7 @@ import (
 	"fyne.io/systray"
 	"github.com/ParetoSecurity/agent/shared"
 	"github.com/ParetoSecurity/agent/trayapp"
+	"github.com/allan-simon/go-singleinstance"
 	"github.com/caarlos0/log"
 	"github.com/pkg/browser"
 	"github.com/spf13/cobra"
@@ -22,6 +23,13 @@ var trayiconCmd = &cobra.Command{
 	Use:   "trayicon",
 	Short: "Display the status of the checks in the system tray",
 	Run: func(cc *cobra.Command, args []string) {
+
+		lockFile, err := singleinstance.CreateLockFile("paretosecurity-tray.lock")
+		if err != nil {
+			log.WithError(err).Fatal("An instance of ParetoSecurity tray application is already running.")
+			return
+		}
+		defer lockFile.Close()
 
 		onExit := func() {
 			log.Info("Exiting...")

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.1
 toolchain go1.24.2
 
 require (
+	github.com/allan-simon/go-singleinstance v0.0.0-20210120080615-d0997106ab37
 	github.com/davecgh/go-spew v1.1.1
 	github.com/fatih/color v1.18.0
 	github.com/fsnotify/fsnotify v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/ProtonMail/go-crypto v1.3.0 h1:ILq8+Sf5If5DCpHQp4PbZdS1J7HDFRXz/+xKBi
 github.com/ProtonMail/go-crypto v1.3.0/go.mod h1:9whxjD8Rbs29b4XWbB8irEcE8KHMqaR2e7GWU1R+/PE=
 github.com/adrg/xdg v0.5.3 h1:xRnxJXne7+oWDatRhR1JLnvuccuIeCoBu2rtuLqQB78=
 github.com/adrg/xdg v0.5.3/go.mod h1:nlTsY+NNiCBGCK2tpm09vRqfVzrc2fLmXGpBLF0zlTQ=
+github.com/allan-simon/go-singleinstance v0.0.0-20210120080615-d0997106ab37 h1:28uU3TtuvQ6KRndxg9TrC868jBWmSKgh0GTXkACCXmA=
+github.com/allan-simon/go-singleinstance v0.0.0-20210120080615-d0997106ab37/go.mod h1:6AXRstqK+32jeFmw89QGL2748+dj34Av4xc/I9oo9BY=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/package.nix
+++ b/package.nix
@@ -15,7 +15,7 @@ in
     version = "${builtins.hashFile "sha256" "${toString ./go.sum}"}";
 
     # Updated with pre-commit, don't change manually
-    vendorHash = "sha256-GMbP34qjn/4ffTW5fxTMdzommcpHf9t3yZJ/jm4Tuzg=";
+    vendorHash = "sha256-tYpTXCx0vp+JX7keu+m5ePrPlGVJZen38HSfQHS4f7s=";
 
     # Uncomment this while developing to skip Go tests
     # doCheck = false;


### PR DESCRIPTION
Checks, link, and unlink must run concurrently and have no issues doing so. The only annoying part is the tray icon, so this adds support for only one instance to it.

ref: https://github.com/teamniteo/pareto/issues/737

