### PR TITLE
Require root access for Linux application updates and simplify update check logic

### DIFF
--- a/checks/linux/application_updates.go
+++ b/checks/linux/application_updates.go
@@ -56,15 +56,11 @@ func (f *ApplicationUpdates) checkUpdates() (bool, string) {
 			log.WithError(err).Error("Failed to list installed flatpak apps")
 			return true, "Flatpak installed apps check failed"
 		}
-		installedApps := f.parseFlatpak(string(installedOutput))
 		updatableApps := f.parseFlatpak(string(updatesOutput))
 		log.WithField("updates", updatesOutput).WithField("installed", installedOutput).Debug("Flatpak updates")
 
-		for app, version := range installedApps {
-			if installed, ok := updatableApps[app]; ok && version != installed {
-				updates = append(updates, "Flatpak")
-				break
-			}
+		if len(updatableApps) > 0 {
+			updates = append(updates, "Flatpak")
 		}
 	}
 

--- a/checks/linux/application_updates.go
+++ b/checks/linux/application_updates.go
@@ -154,7 +154,7 @@ func (f *ApplicationUpdates) FailedMessage() string {
 
 // RequiresRoot returns whether the check requires root access
 func (f *ApplicationUpdates) RequiresRoot() bool {
-	return false
+	return true
 }
 
 // Status returns the status of the check

--- a/checks/linux/application_updates.go
+++ b/checks/linux/application_updates.go
@@ -58,13 +58,9 @@ func (f *ApplicationUpdates) checkUpdates() (bool, string) {
 		}
 		installedApps := f.parseFlatpak(string(installedOutput))
 		updatableApps := f.parseFlatpak(string(updatesOutput))
-		log.WithField("updates", updatesOutput).WithField("installed", installedOutput).Debug("Flatpak updates")
-
-		for app, version := range installedApps {
-			if installed, ok := updatableApps[app]; ok && version != installed {
-				updates = append(updates, "Flatpak")
-				break
-			}
+		log.WithField("updates", updatableApps).WithField("installed", installedApps).Debug("Flatpak updates")
+		if len(updatableApps) > 0 {
+			updates = append(updates, "Flatpak")
 		}
 	}
 

--- a/checks/linux/application_updates.go
+++ b/checks/linux/application_updates.go
@@ -57,7 +57,7 @@ func (f *ApplicationUpdates) checkUpdates() (bool, string) {
 			return true, "Flatpak installed apps check failed"
 		}
 		updatableApps := f.parseFlatpak(string(updatesOutput))
-		log.WithField("updates", updatesOutput).WithField("installed", installedOutput).Debug("Flatpak updates")
+		log.WithField("updates", updatesOutput).Debug("Flatpak updates")
 
 		if len(updatableApps) > 0 {
 			updates = append(updates, "Flatpak")

--- a/checks/linux/application_updates.go
+++ b/checks/linux/application_updates.go
@@ -56,11 +56,15 @@ func (f *ApplicationUpdates) checkUpdates() (bool, string) {
 			log.WithError(err).Error("Failed to list installed flatpak apps")
 			return true, "Flatpak installed apps check failed"
 		}
+		installedApps := f.parseFlatpak(string(installedOutput))
 		updatableApps := f.parseFlatpak(string(updatesOutput))
-		log.WithField("updates", updatesOutput).Debug("Flatpak updates")
+		log.WithField("updates", updatesOutput).WithField("installed", installedOutput).Debug("Flatpak updates")
 
-		if len(updatableApps) > 0 {
-			updates = append(updates, "Flatpak")
+		for app, version := range installedApps {
+			if installed, ok := updatableApps[app]; ok && version != installed {
+				updates = append(updates, "Flatpak")
+				break
+			}
 		}
 	}
 

--- a/checks/linux/application_updates_test.go
+++ b/checks/linux/application_updates_test.go
@@ -93,6 +93,18 @@ func TestApplicationUpdates_checkUpdates(t *testing.T) {
 			}{false, "Updates available for: Flatpak"},
 		},
 		{
+			name: "flatpak with multiple updates from user example",
+			mocks: []shared.RunCommandMock{
+				{Command: "flatpak", Args: []string{"remote-ls", "--app", "--updates", "--columns=application,version"}, Out: "de.swsnr.pictureoftheday\t1.7.0\ndev.zed.Zed\tv0.199.6\norg.nickvision.tubeconverter\t2025.7.2\n", Err: nil},
+				{Command: "flatpak", Args: []string{"list", "--app", "--columns=application,version"}, Out: "app.zen_browser.zen\t1.14.11b\ncom.github.neithern.g4music\t4.5\ncom.mattjakeman.ExtensionManager\t0.6.3\ncom.quexten.Goldwarden\tv0.3.6\nde.swsnr.pictureoftheday\t1.7.0\ndev.zed.Zed\tv0.199.6\norg.nickvision.tubeconverter\t2025.7.2\npage.tesk.Refine\t0.5.10\n", Err: nil},
+			},
+			presentPackageManagers: []string{"flatpak"},
+			expected: struct {
+				passed bool
+				detail string
+			}{false, "Updates available for: Flatpak"},
+		},
+		{
 			name: "flatpak no updates",
 			mocks: []shared.RunCommandMock{
 				{Command: "flatpak", Args: []string{"remote-ls", "--app", "--updates", "--columns=application,version"}, Out: "", Err: nil},


### PR DESCRIPTION
Enhance the update check logic for Flatpak applications and ensure that root access is required for performing update checks.