### PR TITLE
Refine firewall detection logic

### DIFF
--- a/checks/linux/firewall_test.go
+++ b/checks/linux/firewall_test.go
@@ -123,6 +123,34 @@ num  target     prot opt source               destination
 			mockError:      nil,
 			expectedResult: true,
 		},
+		{
+			name: "Real iptables with ACCEPT policy and ts-input chain should fail",
+			mockOutput: `Chain INPUT (policy ACCEPT)
+num  target     prot opt source               destination         
+1    ts-input   all  --  anywhere             anywhere            
+`,
+			mockError:      nil,
+			expectedResult: false,
+		},
+		{
+			name: "Iptables with DROP rules should pass",
+			mockOutput: `Chain INPUT (policy ACCEPT)
+num  target     prot opt source               destination         
+1    ACCEPT     tcp  --  0.0.0.0/0            0.0.0.0/0           tcp dpt:22
+2    DROP       all  --  0.0.0.0/0            0.0.0.0/0           
+`,
+			mockError:      nil,
+			expectedResult: true,
+		},
+		{
+			name: "UFW chain should pass",
+			mockOutput: `Chain INPUT (policy ACCEPT)
+num  target     prot opt source               destination         
+1    ufw-before-logging-input  all  --  anywhere             anywhere            
+`,
+			mockError:      nil,
+			expectedResult: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -182,6 +210,13 @@ num  target     prot opt source               destination
 `,
 			expectedResult: false,
 		},
+		{
+			name: "Policy ACCEPT with no rules should fail",
+			mockOutput: `Chain INPUT (policy ACCEPT)
+num  target     prot opt source               destination         
+`,
+			expectedResult: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -204,10 +239,11 @@ func TestFirewall_Run(t *testing.T) {
 		expectedPassed bool
 	}{
 		{
-			name: "Iptables active",
+			name: "Iptables active with DROP rule",
 			mockOutput: `Chain INPUT (policy ACCEPT)
 num  target     prot opt source               destination         
 1    ACCEPT     tcp  --  0.0.0.0/0            0.0.0.0/0           tcp dpt:22
+2    DROP       all  --  0.0.0.0/0            0.0.0.0/0           
 `,
 			mockError:      nil,
 			expectedPassed: true,


### PR DESCRIPTION
Firewall is active if:
1. The default policy is restrictive (DROP/REJECT), OR
2. There are explicit DROP/REJECT rules in the INPUT chain, OR
3. There's a custom chain AND it's a known firewall chain (nixos-fw, ufw-, etc)

ref: https://github.com/ParetoSecurity/agent/issues/39