### PR TITLE
Modify paretosecurity.service configuration

### DIFF
--- a/apt/paretosecurity.service
+++ b/apt/paretosecurity.service
@@ -13,6 +13,4 @@ ProtectSystem=full
 ProtectHome=yes
 StandardOutput=journal
 StandardError=journal
-
-[Install]
-WantedBy=multi-user.target
+TimeoutStartSec=30


### PR DESCRIPTION
Removed installation section and added timeout setting to be compatible with systemd 259+.