### PR TITLE
chore: stop sending LastCheck timestamp

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
                   rev = final.lib.substring 0 8 (builtins.hashFile "sha256" ./go.sum);
                 };
                 version = "${builtins.hashFile "sha256" "${toString ./go.sum}"}";
-                vendorHash = "sha256-y9x5RplVOr4mIOPTg86VvFWXkvZ1FTc9Ulc/yXb9/WU=";
+                vendorHash = "sha256-b+PmTUWt8rj69IlC+MAgnrCquoUyvY1ei0HNEhBX9lM=";
               });
             }
           );

--- a/team/report.go
+++ b/team/report.go
@@ -25,7 +25,6 @@ type Report struct {
 	DisabledCount     int                         `json:"disabledCount"`
 	Device            shared.ReportingDevice      `json:"device"`
 	Version           string                      `json:"version"`
-	LastCheck         string                      `json:"lastCheck"`
 	SignificantChange string                      `json:"significantChange"`
 	State             map[string]check.CheckState `json:"state"`
 }
@@ -75,7 +74,6 @@ func NowReport(all []claims.Claim) Report {
 		DisabledCount:     disabled,
 		Device:            shared.CurrentReportingDevice(),
 		Version:           shared.Version,
-		LastCheck:         time.Now().Format(time.RFC3339),
 		SignificantChange: hex.EncodeToString(significantChange[:]),
 		State:             checkStates,
 	}


### PR DESCRIPTION
Cloud app no longer require this timestamp.

Ref: https://github.com/teamniteo/pareto/issues/723