### PR TITLE
Suppress the --verbose suggestion when it's already used

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -93,7 +93,9 @@ func runCheckCommand(config *CheckConfig, skipUUIDs []string, onlyUUID string) {
 					config.LogErrorf("Failed check: %s (UUID: %s)", check.Name, check.UUID)
 				}
 			}
-			config.LogFatal("You can use `paretosecurity check --verbose` to get a detailed report.")
+			if !verbose {
+				config.LogFatal("You can use `paretosecurity check --verbose` to get a detailed report.")
+			}
 		}
 
 	case <-ctx.Done():


### PR DESCRIPTION
If the user is already using `--verbose`, there's no need to advertise that option:
```
$ paretosecurity check --verbose 2>&1 | tail
...
  ⨯ Failed check: Remote login is disabled (UUID: 4ced961d-7cfc-4e7b-8f80-195f6379446e)
  ⨯ Failed check: SSH keys have sufficient algorithm strength (UUID: ef69f752-0e89-46e2-a644-310429ae5f45)
  ⨯ You can use `paretosecurity check --verbose` to get a detailed report.
```