### PR TITLE
fix: Revert artifact signing action

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,5 +20,9 @@ updates:
       github-actions:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: azure/artifact-signing-action
+        versions:
+          - ">=2"
     schedule:
       interval: daily

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,8 @@ jobs:
           mv tray_windows_amd64_v1/paretosecurity-tray.exe paretosecurity-tray.exe
           mv agent_windows_amd64_v1/paretosecurity.exe paretosecurity.exe
       - name: Sign Windows artifacts (x64)
-        uses: azure/artifact-signing-action@v2
+        # West Europe Artifact Signing fails with v2; keep v1 until Azure supports it.
+        uses: azure/artifact-signing-action@v1
         with:
           azure-client-id: ${{ env.AZURE_CLIENT_ID }}
           azure-client-secret: ${{ env.AZURE_CLIENT_SECRET }}


### PR DESCRIPTION
West Europe Artifact Signing fails with v2; keep v1 until Azure supports it.