### PR TITLE
fix: Handle package manager config

### DIFF
--- a/checks/shared/package_manager_supply_chain.go
+++ b/checks/shared/package_manager_supply_chain.go
@@ -13,10 +13,11 @@ const minReleaseAgeSeconds = 7 * 24 * 60 * 60
 const minReleaseAgeMinutes = 7 * 24 * 60
 
 type packageManagerConfig struct {
-	path       string
+	paths      []string
 	binaries   []string
-	validate   func(string) []string
-	passDetail string
+	validate   func(string, string) []string
+	missing    func([]string) string
+	passDetail func(string) string
 }
 
 // PackageManagerSupplyChain verifies package managers delay newly published packages.
@@ -30,6 +31,8 @@ type PackageManagerSupplyChain struct {
 	FileExists func(string) bool
 	LookPath   func(string) (string, error)
 	Getenv     func(string) string
+	RunCommand func(string, ...string) ([]byte, error)
+	Versions   map[string]string
 }
 
 // Name returns the name of the check.
@@ -102,12 +105,12 @@ func (p *PackageManagerSupplyChain) validationFailures() []string {
 	var failures []string
 
 	for _, config := range p.configs() {
-		if contents, ok := p.readConfig(config.path); ok {
-			failures = append(failures, config.validate(contents)...)
+		if contents, path, ok := p.activeConfig(config.paths); ok {
+			failures = append(failures, config.validate(contents, path)...)
 			continue
 		}
 		if p.anyBinaryInstalled(config.binaries...) {
-			failures = append(failures, config.path+" is missing")
+			failures = append(failures, config.missing(config.paths))
 		}
 	}
 
@@ -118,8 +121,8 @@ func (p *PackageManagerSupplyChain) passingDetails() []string {
 	var details []string
 
 	for _, config := range p.configs() {
-		if contents, ok := p.readConfig(config.path); ok && len(config.validate(contents)) == 0 {
-			details = append(details, config.passDetail)
+		if contents, path, ok := p.activeConfig(config.paths); ok && len(config.validate(contents, path)) == 0 {
+			details = append(details, config.passDetail(path))
 		}
 	}
 	if len(details) == 0 {
@@ -130,8 +133,10 @@ func (p *PackageManagerSupplyChain) passingDetails() []string {
 
 func (p *PackageManagerSupplyChain) hasConfigFile() bool {
 	for _, config := range p.configs() {
-		if p.fileExists(config.path) {
-			return true
+		for _, path := range config.paths {
+			if p.fileExists(path) {
+				return true
+			}
 		}
 	}
 	return false
@@ -154,41 +159,55 @@ func (p *PackageManagerSupplyChain) configs() []packageManagerConfig {
 	home := p.homeDir()
 	return []packageManagerConfig{
 		{
-			path:       filepath.Join(home, ".npmrc"),
+			paths:      []string{filepath.Join(home, ".npmrc")},
 			binaries:   []string{"npm"},
-			validate:   validateNpmrc,
-			passDetail: "~/.npmrc delays npm-compatible package releases and pins exact versions",
+			validate:   p.validateNpmConfig,
+			missing:    firstConfigPathMissing,
+			passDetail: func(string) string { return "~/.npmrc delays npm-compatible package releases and pins exact versions" },
 		},
 		{
-			path:       filepath.Join(home, ".yarnrc.yml"),
+			paths:      []string{filepath.Join(home, ".yarnrc.yml")},
 			binaries:   []string{"yarn"},
-			validate:   validateYarnrc,
-			passDetail: "~/.yarnrc.yml delays Yarn package releases",
+			validate:   func(contents string, _ string) []string { return validateYarnrc(contents) },
+			missing:    firstConfigPathMissing,
+			passDetail: func(string) string { return "~/.yarnrc.yml delays Yarn package releases" },
 		},
 		{
-			path:       p.pnpmConfigPath(),
+			paths:      p.pnpmConfigPaths(),
 			binaries:   []string{"pnpm"},
 			validate:   validatePnpmConfig,
-			passDetail: p.pnpmConfigPath() + " delays pnpm package releases",
+			missing:    pnpmConfigMissing,
+			passDetail: func(path string) string { return path + " delays pnpm package releases" },
 		},
 		{
-			path:       filepath.Join(home, ".bunfig.toml"),
+			paths:      []string{filepath.Join(home, ".bunfig.toml")},
 			binaries:   []string{"bun"},
-			validate:   validateBunfig,
-			passDetail: "~/.bunfig.toml delays Bun package releases",
+			validate:   func(contents string, _ string) []string { return validateBunfig(contents) },
+			missing:    firstConfigPathMissing,
+			passDetail: func(string) string { return "~/.bunfig.toml delays Bun package releases" },
 		},
 		{
-			path:       p.uvConfigPath(),
+			paths:      []string{p.uvConfigPath()},
 			binaries:   []string{"uv"},
-			validate:   validateUv,
-			passDetail: p.uvConfigPath() + " excludes Python packages newer than 7 days",
+			validate:   func(contents string, _ string) []string { return validateUv(contents) },
+			missing:    firstConfigPathMissing,
+			passDetail: func(path string) string { return path + " excludes Python packages newer than 7 days" },
 		},
 		{
-			path:       filepath.Join(home, ".pypirc"),
-			validate:   validatePypirc,
-			passDetail: "~/.pypirc has no plaintext credentials",
+			paths:      []string{filepath.Join(home, ".pypirc")},
+			validate:   func(contents string, _ string) []string { return validatePypirc(contents) },
+			missing:    firstConfigPathMissing,
+			passDetail: func(string) string { return "~/.pypirc has no plaintext credentials" },
 		},
 	}
+}
+
+func firstConfigPathMissing(paths []string) string {
+	return paths[0] + " is missing"
+}
+
+func pnpmConfigMissing(paths []string) string {
+	return "pnpm config is missing (checked " + strings.Join(paths, ", ") + ")"
 }
 
 func (p *PackageManagerSupplyChain) readConfig(path string) (string, bool) {
@@ -197,6 +216,15 @@ func (p *PackageManagerSupplyChain) readConfig(path string) (string, bool) {
 		return "", false
 	}
 	return string(contents), true
+}
+
+func (p *PackageManagerSupplyChain) activeConfig(paths []string) (string, string, bool) {
+	for _, path := range paths {
+		if contents, ok := p.readConfig(path); ok {
+			return contents, path, true
+		}
+	}
+	return "", "", false
 }
 
 func (p *PackageManagerSupplyChain) readFile(path string) ([]byte, error) {
@@ -219,6 +247,28 @@ func (p *PackageManagerSupplyChain) lookPath(name string) (string, error) {
 		return p.LookPath(name)
 	}
 	return exec.LookPath(name)
+}
+
+func (p *PackageManagerSupplyChain) packageManagerVersion(name string) string {
+	if version, ok := p.Versions[name]; ok {
+		return version
+	}
+	path, err := p.lookPath(name)
+	if err != nil {
+		return ""
+	}
+	output, err := p.runCommand(path, "--version")
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func (p *PackageManagerSupplyChain) runCommand(name string, args ...string) ([]byte, error) {
+	if p.RunCommand != nil {
+		return p.RunCommand(name, args...)
+	}
+	return exec.Command(name, args...).Output()
 }
 
 func (p *PackageManagerSupplyChain) homeDir() string {
@@ -253,9 +303,12 @@ func (p *PackageManagerSupplyChain) uvConfigPath() string {
 	return filepath.Join(configHome, "uv", "uv.toml")
 }
 
-func (p *PackageManagerSupplyChain) pnpmConfigPath() string {
+func (p *PackageManagerSupplyChain) pnpmConfigPaths() []string {
 	if configHome := p.env("XDG_CONFIG_HOME"); configHome != "" {
-		return filepath.Join(configHome, "pnpm", "config.yaml")
+		return []string{
+			filepath.Join(configHome, "pnpm", "rc"),
+			filepath.Join(configHome, "pnpm", "config.yaml"),
+		}
 	}
 
 	switch p.goos() {
@@ -264,12 +317,27 @@ func (p *PackageManagerSupplyChain) pnpmConfigPath() string {
 		if localAppData == "" {
 			localAppData = filepath.Join(p.homeDir(), "AppData", "Local")
 		}
-		return filepath.Join(localAppData, "pnpm", "config", "config.yaml")
+		return []string{
+			filepath.Join(localAppData, "pnpm", "config", "rc"),
+			filepath.Join(localAppData, "pnpm", "config", "config.yaml"),
+		}
 	case "darwin":
-		return filepath.Join(p.homeDir(), "Library", "Preferences", "pnpm", "config.yaml")
+		return []string{
+			filepath.Join(p.homeDir(), "Library", "Preferences", "pnpm", "rc"),
+			filepath.Join(p.homeDir(), "Library", "Preferences", "pnpm", "config.yaml"),
+			filepath.Join(p.homeDir(), ".config", "pnpm", "rc"),
+			filepath.Join(p.homeDir(), ".config", "pnpm", "config.yaml"),
+		}
 	default:
-		return filepath.Join(p.homeDir(), ".config", "pnpm", "config.yaml")
+		return []string{
+			filepath.Join(p.homeDir(), ".config", "pnpm", "rc"),
+			filepath.Join(p.homeDir(), ".config", "pnpm", "config.yaml"),
+		}
 	}
+}
+
+func (p *PackageManagerSupplyChain) pnpmConfigPath() string {
+	return p.pnpmConfigPaths()[0]
 }
 
 func (p *PackageManagerSupplyChain) env(name string) string {
@@ -286,21 +354,85 @@ func (p *PackageManagerSupplyChain) goos() string {
 	return runtime.GOOS
 }
 
+func (p *PackageManagerSupplyChain) validateNpmConfig(contents string, _ string) []string {
+	failures := validateNpmrc(contents)
+	if len(failures) != 0 || !p.anyBinaryInstalled("npm") || !npmConfigUsesMinReleaseAge(contents) {
+		return failures
+	}
+	version := p.packageManagerVersion("npm")
+	if version == "" {
+		failures = append(failures, "npm version could not be determined, so ~/.npmrc min-release-age could not be verified")
+		return failures
+	}
+	if !versionAtLeast(version, "11.14.0") {
+		failures = append(failures, "npm is older than 11.14.0 and does not enforce ~/.npmrc min-release-age")
+	}
+	return failures
+}
+
+func npmConfigUsesMinReleaseAge(contents string) bool {
+	_, ok := keyValuePairs(contents)["min-release-age"]
+	return ok
+}
+
 func validateNpmrc(contents string) []string {
 	values := keyValuePairs(contents)
 	var failures []string
 
-	if integerValue(values["min-release-age"]) < 7 {
-		failures = append(failures, "~/.npmrc min-release-age is below 7 days")
-	}
-	if integerValue(values["minimum-release-age"]) < minReleaseAgeMinutes {
-		failures = append(failures, "~/.npmrc minimum-release-age is below 10080 minutes")
+	if integerValue(values["min-release-age"]) < 7 && integerValue(values["minimum-release-age"]) < minReleaseAgeMinutes {
+		failures = append(failures, "~/.npmrc release age is below 7 days; set either min-release-age >= 7 or minimum-release-age >= 10080")
 	}
 	if strings.ToLower(values["save-exact"]) != "true" {
 		failures = append(failures, "~/.npmrc save-exact is not enabled")
 	}
 
 	return failures
+}
+
+func versionAtLeast(version string, minimumVersion string) bool {
+	if version == "" || strings.Contains(version, "-") {
+		return false
+	}
+	current := versionComponents(version)
+	minimum := versionComponents(minimumVersion)
+	length := len(current)
+	if len(minimum) > length {
+		length = len(minimum)
+	}
+	for index := 0; index < length; index++ {
+		currentPart := 0
+		if index < len(current) {
+			currentPart = current[index]
+		}
+		minimumPart := 0
+		if index < len(minimum) {
+			minimumPart = minimum[index]
+		}
+		if currentPart != minimumPart {
+			return currentPart > minimumPart
+		}
+	}
+	return true
+}
+
+func versionComponents(version string) []int {
+	parts := strings.Split(strings.TrimLeft(version, "vV"), ".")
+	components := make([]int, 0, len(parts))
+	for _, part := range parts {
+		number := ""
+		for _, character := range part {
+			if character < '0' || character > '9' {
+				break
+			}
+			number += string(character)
+		}
+		component, err := strconv.Atoi(number)
+		if err != nil {
+			component = 0
+		}
+		components = append(components, component)
+	}
+	return components
 }
 
 func validateYarnrc(contents string) []string {
@@ -311,14 +443,14 @@ func validateYarnrc(contents string) []string {
 	return nil
 }
 
-func validatePnpmConfig(contents string) []string {
+func validatePnpmConfig(contents string, path string) []string {
 	values := keyValuePairs(contents)
 	releaseAge := integerValue(values["minimumreleaseage"])
 	if releaseAge == 0 {
 		releaseAge = integerValue(values["minimum-release-age"])
 	}
 	if releaseAge < minReleaseAgeMinutes {
-		return []string{"pnpm minimumReleaseAge is below 10080 minutes"}
+		return []string{path + " minimumReleaseAge is below 10080 minutes"}
 	}
 	return nil
 }

--- a/checks/shared/package_manager_supply_chain_test.go
+++ b/checks/shared/package_manager_supply_chain_test.go
@@ -42,7 +42,6 @@ func TestPackageManagerSupplyChain_RunPassesWithProtectedConfigs(t *testing.T) {
 	home := t.TempDir()
 	writeFile(t, filepath.Join(home, ".npmrc"), `
 min-release-age=7
-minimum-release-age=10080
 save-exact=true
 `)
 	writeFile(t, filepath.Join(home, ".yarnrc.yml"), `
@@ -109,15 +108,130 @@ password = pypi-secret
 
 	assert.False(t, check.Passed())
 	assert.Equal(t, stringsJoin(
-		"~/.npmrc min-release-age is below 7 days",
-		"~/.npmrc minimum-release-age is below 10080 minutes",
+		"~/.npmrc release age is below 7 days; set either min-release-age >= 7 or minimum-release-age >= 10080",
 		"~/.npmrc save-exact is not enabled",
 		"~/.yarnrc.yml npmMinimalAgeGate is below 10080 minutes",
-		"pnpm minimumReleaseAge is below 10080 minutes",
+		filepath.Join(home, ".config", "pnpm", "config.yaml")+" minimumReleaseAge is below 10080 minutes",
 		"~/.bunfig.toml minimumReleaseAge is below 604800 seconds",
 		"uv exclude-newer is below 7 days",
 		"~/.pypirc contains plaintext credentials",
 	), check.Status())
+}
+
+func TestPackageManagerSupplyChain_RunPassesWithMinimumReleaseAgeOnly(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".npmrc"), `
+minimum-release-age=10080
+save-exact=true
+`)
+	check := testPackageManagerSupplyChain(home, nil, nil)
+
+	require.NoError(t, check.Run())
+
+	assert.True(t, check.Passed())
+	assert.Equal(t, "~/.npmrc delays npm-compatible package releases and pins exact versions", check.Status())
+}
+
+func TestPackageManagerSupplyChain_RunPassesWithMinimumReleaseAgeOnlyAndOldNpm(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".npmrc"), `
+minimum-release-age=10080
+save-exact=true
+`)
+	check := testPackageManagerSupplyChain(home, nil, map[string]bool{"npm": true})
+	check.Versions = map[string]string{"npm": "11.13.0"}
+
+	require.NoError(t, check.Run())
+
+	assert.True(t, check.Passed())
+	assert.Equal(t, "~/.npmrc delays npm-compatible package releases and pins exact versions", check.Status())
+}
+
+func TestPackageManagerSupplyChain_RunFailsWithUnsupportedNpmVersion(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".npmrc"), `
+min-release-age=7
+save-exact=true
+`)
+	check := testPackageManagerSupplyChain(home, nil, map[string]bool{"npm": true})
+	check.Versions = map[string]string{"npm": "11.13.0"}
+
+	require.NoError(t, check.Run())
+
+	assert.False(t, check.Passed())
+	assert.Equal(t, "npm is older than 11.14.0 and does not enforce ~/.npmrc min-release-age", check.Status())
+}
+
+func TestPackageManagerSupplyChain_RunFailsWithPrereleaseNpmVersion(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".npmrc"), `
+min-release-age=7
+save-exact=true
+`)
+	check := testPackageManagerSupplyChain(home, nil, map[string]bool{"npm": true})
+	check.Versions = map[string]string{"npm": "11.14.0-rc.1"}
+
+	require.NoError(t, check.Run())
+
+	assert.False(t, check.Passed())
+	assert.Equal(t, "npm is older than 11.14.0 and does not enforce ~/.npmrc min-release-age", check.Status())
+}
+
+func TestPackageManagerSupplyChain_RunFailsWithUnknownNpmVersion(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".npmrc"), `
+min-release-age=7
+save-exact=true
+`)
+	check := testPackageManagerSupplyChain(home, nil, map[string]bool{"npm": true})
+	check.Versions = map[string]string{"npm": ""}
+
+	require.NoError(t, check.Run())
+
+	assert.False(t, check.Passed())
+	assert.Equal(t, "npm version could not be determined, so ~/.npmrc min-release-age could not be verified", check.Status())
+}
+
+func TestPackageManagerSupplyChain_RunPassesWithSupportedNpmVersion(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".npmrc"), `
+min-release-age=7
+save-exact=true
+`)
+	check := testPackageManagerSupplyChain(home, nil, map[string]bool{"npm": true})
+	check.Versions = map[string]string{"npm": "11.14.0"}
+
+	require.NoError(t, check.Run())
+
+	assert.True(t, check.Passed())
+	assert.Equal(t, "~/.npmrc delays npm-compatible package releases and pins exact versions", check.Status())
+}
+
+func TestPackageManagerSupplyChain_ReadsNpmVersionThroughRunner(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".npmrc"), `
+min-release-age=7
+save-exact=true
+`)
+	check := testPackageManagerSupplyChain(home, nil, map[string]bool{"npm": true})
+	check.RunCommand = func(name string, args ...string) ([]byte, error) {
+		assert.Equal(t, "/usr/bin/npm", name)
+		assert.Equal(t, []string{"--version"}, args)
+		return []byte("11.14.0\n"), nil
+	}
+
+	require.NoError(t, check.Run())
+
+	assert.True(t, check.Passed())
+}
+
+func TestPackageManagerSupplyChain_VersionAtLeast(t *testing.T) {
+	assert.False(t, versionAtLeast("", "11.14.0"))
+	assert.False(t, versionAtLeast("11.13.0", "11.14.0"))
+	assert.False(t, versionAtLeast("11.14.0-rc.1", "11.14.0"))
+	assert.True(t, versionAtLeast("11.14.0", "11.14.0"))
+	assert.True(t, versionAtLeast("v11.14.0", "11.14.0"))
+	assert.True(t, versionAtLeast("12", "11.14.0"))
 }
 
 func TestPackageManagerSupplyChain_RunFailsWhenBinaryConfigIsMissing(t *testing.T) {
@@ -136,10 +250,26 @@ func TestPackageManagerSupplyChain_RunFailsWhenBinaryConfigIsMissing(t *testing.
 	assert.Equal(t, stringsJoin(
 		filepath.Join(home, ".npmrc")+" is missing",
 		filepath.Join(home, ".yarnrc.yml")+" is missing",
-		filepath.Join(home, ".config", "pnpm", "config.yaml")+" is missing",
+		"pnpm config is missing (checked "+filepath.Join(home, ".config", "pnpm", "rc")+", "+filepath.Join(home, ".config", "pnpm", "config.yaml")+")",
 		filepath.Join(home, ".bunfig.toml")+" is missing",
 		filepath.Join(home, ".config", "uv", "uv.toml")+" is missing",
 	), check.Status())
+}
+
+func TestPackageManagerSupplyChain_RunUsesActivePnpmConfig(t *testing.T) {
+	home := t.TempDir()
+	writeFile(t, filepath.Join(home, ".config", "pnpm", "config.yaml"), `
+minimumReleaseAge: 10079
+`)
+	writeFile(t, filepath.Join(home, ".config", "pnpm", "rc"), `
+minimum-release-age=10080
+`)
+	check := testPackageManagerSupplyChain(home, nil, map[string]bool{"pnpm": true})
+
+	require.NoError(t, check.Run())
+
+	assert.True(t, check.Passed())
+	assert.Equal(t, filepath.Join(home, ".config", "pnpm", "rc")+" delays pnpm package releases", check.Status())
 }
 
 func TestPackageManagerSupplyChain_WindowsUvConfigPath(t *testing.T) {
@@ -222,15 +352,29 @@ func TestPackageManagerSupplyChain_PnpmConfigPath(t *testing.T) {
 
 	check := testPackageManagerSupplyChain(home, nil, nil)
 	check.GOOS = "linux"
-	assert.Equal(t, filepath.Join(home, ".config", "pnpm", "config.yaml"), check.pnpmConfigPath())
+	assert.Equal(t, filepath.Join(home, ".config", "pnpm", "rc"), check.pnpmConfigPath())
+	assert.Equal(t, []string{
+		filepath.Join(home, ".config", "pnpm", "rc"),
+		filepath.Join(home, ".config", "pnpm", "config.yaml"),
+	}, check.pnpmConfigPaths())
 
 	check = testPackageManagerSupplyChain(home, nil, nil)
 	check.GOOS = "darwin"
-	assert.Equal(t, filepath.Join(home, "Library", "Preferences", "pnpm", "config.yaml"), check.pnpmConfigPath())
+	assert.Equal(t, filepath.Join(home, "Library", "Preferences", "pnpm", "rc"), check.pnpmConfigPath())
+	assert.Equal(t, []string{
+		filepath.Join(home, "Library", "Preferences", "pnpm", "rc"),
+		filepath.Join(home, "Library", "Preferences", "pnpm", "config.yaml"),
+		filepath.Join(home, ".config", "pnpm", "rc"),
+		filepath.Join(home, ".config", "pnpm", "config.yaml"),
+	}, check.pnpmConfigPaths())
 
 	check = testPackageManagerSupplyChain(home, nil, nil)
 	check.GOOS = "windows"
-	assert.Equal(t, filepath.Join(home, "AppData", "Local", "pnpm", "config", "config.yaml"), check.pnpmConfigPath())
+	assert.Equal(t, filepath.Join(home, "AppData", "Local", "pnpm", "config", "rc"), check.pnpmConfigPath())
+	assert.Equal(t, []string{
+		filepath.Join(home, "AppData", "Local", "pnpm", "config", "rc"),
+		filepath.Join(home, "AppData", "Local", "pnpm", "config", "config.yaml"),
+	}, check.pnpmConfigPaths())
 }
 
 func TestPackageManagerSupplyChain_PnpmConfigPathUsesXdgConfigHome(t *testing.T) {
@@ -244,7 +388,32 @@ func TestPackageManagerSupplyChain_PnpmConfigPathUsesXdgConfigHome(t *testing.T)
 		return ""
 	}
 
-	assert.Equal(t, filepath.Join(configHome, "pnpm", "config.yaml"), check.pnpmConfigPath())
+	assert.Equal(t, filepath.Join(configHome, "pnpm", "rc"), check.pnpmConfigPath())
+	assert.Equal(t, []string{
+		filepath.Join(configHome, "pnpm", "rc"),
+		filepath.Join(configHome, "pnpm", "config.yaml"),
+	}, check.pnpmConfigPaths())
+}
+
+func TestPackageManagerSupplyChain_RunUsesPnpmXdgConfigHomeRc(t *testing.T) {
+	home := t.TempDir()
+	configHome := filepath.Join(home, "xdg")
+	pnpmConfig := filepath.Join(configHome, "pnpm", "rc")
+	writeFile(t, pnpmConfig, `
+minimum-release-age=10080
+`)
+	check := testPackageManagerSupplyChain(home, nil, map[string]bool{"pnpm": true})
+	check.Getenv = func(name string) string {
+		if name == "XDG_CONFIG_HOME" {
+			return configHome
+		}
+		return ""
+	}
+
+	require.NoError(t, check.Run())
+
+	assert.True(t, check.Passed())
+	assert.Equal(t, pnpmConfig+" delays pnpm package releases", check.Status())
 }
 
 func TestKeyValuePairsPreservesQuotedCommentCharacters(t *testing.T) {

--- a/checks/shared/package_manager_supply_chain_versions_test.go
+++ b/checks/shared/package_manager_supply_chain_versions_test.go
@@ -1,0 +1,110 @@
+package shared
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPackageManagerSupplyChain_RealPackageManagerVersions(t *testing.T) {
+	if os.Getenv("PARETO_TEST_PACKAGE_MANAGER_VERSIONS") == "" {
+		t.Skip("set PARETO_TEST_PACKAGE_MANAGER_VERSIONS=1 to run real npm/pnpm version checks")
+	}
+	requireCommand(t, "npx")
+
+	t.Run("npm 11.15.0 accepts comments", func(t *testing.T) {
+		home := t.TempDir()
+		npmrc := filepath.Join(home, ".npmrc")
+		writeFile(t, npmrc, `
+# full-line comment
+min-release-age=7 # trailing comment
+save-exact=true ; trailing comment
+`)
+		emptyNpmrc := filepath.Join(home, "empty.npmrc")
+		writeFile(t, emptyNpmrc, "")
+
+		assert.Equal(t, "7", runTool(t, home, emptyNpmrc, "npx", "--yes", "-p", "npm@11.15.0", "npm", "--userconfig", npmrc, "config", "get", "min-release-age"))
+		assert.Equal(t, "true", runTool(t, home, emptyNpmrc, "npx", "--yes", "-p", "npm@11.15.0", "npm", "--userconfig", npmrc, "config", "get", "save-exact"))
+	})
+
+	t.Run("npm 11.13.0 does not apply min release age", func(t *testing.T) {
+		home := t.TempDir()
+		npmrc := filepath.Join(home, ".npmrc")
+		writeFile(t, npmrc, `
+min-release-age=7
+save-exact=true
+`)
+		emptyNpmrc := filepath.Join(home, "empty.npmrc")
+		writeFile(t, emptyNpmrc, "")
+
+		assert.Equal(t, "null", runTool(t, home, emptyNpmrc, "npx", "--yes", "-p", "npm@11.13.0", "npm", "--userconfig", npmrc, "config", "get", "min-release-age"))
+	})
+
+	t.Run("pnpm 10.24.0 accepts rc comments", func(t *testing.T) {
+		home := t.TempDir()
+		xdgConfigHome := filepath.Join(home, "xdg")
+		pnpmrc := filepath.Join(xdgConfigHome, "pnpm", "rc")
+		writeFile(t, pnpmrc, `
+; full-line comment
+minimum-release-age=10080 # trailing comment
+`)
+		emptyNpmrc := filepath.Join(home, "empty.npmrc")
+		writeFile(t, emptyNpmrc, "")
+
+		assert.Equal(t, "10080", runToolWithEnv(t, home, emptyNpmrc, []string{"XDG_CONFIG_HOME=" + xdgConfigHome}, "npx", "--yes", "-p", "pnpm@10.24.0", "pnpm", "config", "get", "minimumReleaseAge"))
+	})
+
+	t.Run("pnpm 11.4.0 accepts config yaml comments", func(t *testing.T) {
+		home := t.TempDir()
+		xdgConfigHome := filepath.Join(home, "xdg")
+		pnpmConfig := filepath.Join(xdgConfigHome, "pnpm", "config.yaml")
+		writeFile(t, pnpmConfig, `
+# full-line comment
+minimumReleaseAge: 10080 # trailing comment
+`)
+		emptyNpmrc := filepath.Join(home, "empty.npmrc")
+		writeFile(t, emptyNpmrc, "")
+
+		assert.Equal(t, "10080", runToolWithEnv(t, home, emptyNpmrc, []string{"XDG_CONFIG_HOME=" + xdgConfigHome}, "npx", "--yes", "-p", "pnpm@11.4.0", "pnpm", "config", "get", "minimumReleaseAge"))
+	})
+}
+
+func requireCommand(t *testing.T, name string) {
+	t.Helper()
+	_, err := exec.LookPath(name)
+	require.NoError(t, err)
+}
+
+func runTool(t *testing.T, home string, npmUserConfig string, name string, args ...string) string {
+	t.Helper()
+	return runToolWithEnv(t, home, npmUserConfig, nil, name, args...)
+}
+
+func runToolWithEnv(t *testing.T, home string, npmUserConfig string, extraEnv []string, name string, args ...string) string {
+	t.Helper()
+	command := exec.Command(name, args...)
+	command.Dir = home
+	globalNpmConfig := filepath.Join(home, "empty-global.npmrc")
+	require.NoError(t, os.WriteFile(globalNpmConfig, []byte(""), 0o600))
+	command.Env = append(os.Environ(),
+		"HOME="+home,
+		"NPM_CONFIG_AUDIT=false",
+		"NPM_CONFIG_FUND=false",
+		"NPM_CONFIG_GLOBALCONFIG="+globalNpmConfig,
+		"NPM_CONFIG_LOGLEVEL=error",
+		"NPM_CONFIG_UPDATE_NOTIFIER=false",
+		"NPM_CONFIG_USERCONFIG="+npmUserConfig,
+	)
+	command.Env = append(command.Env, extraEnv...)
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+	output, err := command.Output()
+	require.NoError(t, err, stderr.String())
+	return strings.TrimSpace(string(output))
+}


### PR DESCRIPTION

- Native npm versions before 11.14.0 do not enforce `min-release-age`, so the check now warns/fails even when `.npmrc` looks valid.
- `.npmrc` accepts either `min-release-age=7` or `minimum-release-age=10080` for compatibility.
- pnpm now checks `rc` and `config.yaml`, prefers the active `rc` path, and handles `#` / `;` comments.

Refs https://github.com/teamniteo/pareto/issues/855