### PR TITLE
fix: Gate linkDevice host override behind env var

### DIFF
--- a/cmd/link.go
+++ b/cmd/link.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
+	"os"
+	"strconv"
 
 	"github.com/ParetoSecurity/agent/notify"
 	shared "github.com/ParetoSecurity/agent/shared"
@@ -12,6 +14,15 @@ import (
 	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 )
+
+// host is untrusted input from an external URL; require explicit opt-in before trusting it.
+// https://github.com/teamniteo/pareto/issues/863
+const allowHostOverrideEnv = "PARETO_ALLOW_HOST_OVERRIDE"
+
+func hostOverrideAllowed() bool {
+	allowed, _ := strconv.ParseBool(os.Getenv(allowHostOverrideEnv))
+	return allowed
+}
 
 var linkCmd = &cobra.Command{
 	Use:   "link <url>",
@@ -52,6 +63,13 @@ func runLinkCommand(teamURL string) error {
 	if err != nil {
 		log.WithError(err).Warn("failed to parse enrollment URL")
 		return err
+	}
+
+	// Only honor an explicit host override when opted in via env var; otherwise
+	// always enroll against the production Pareto Cloud API.
+	if host != "" && !hostOverrideAllowed() {
+		log.Warnf("ignoring host override from link URL; set %s=1 to allow it", allowHostOverrideEnv)
+		host = ""
 	}
 
 	// Enroll the device

--- a/cmd/link_test.go
+++ b/cmd/link_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"testing"
 
 	"github.com/ParetoSecurity/agent/shared"
@@ -83,6 +84,84 @@ func TestRunLinkCommand_Success(t *testing.T) {
 	assert.Equal(t, "2429c49e-37bb-41bb-9077-6bb6202e255b", shared.Config.TeamID)
 	assert.NotEmpty(t, shared.Config.AuthToken)
 	assert.Equal(t, "https://cloud.paretosecurity.com", shared.Config.TeamAPI)
+}
+
+func TestRunLinkCommand_HostOverrideIgnoredByDefault(t *testing.T) {
+	defer gock.Off()
+
+	tempDir := t.TempDir()
+	originalConfigPath := shared.ConfigPath
+	shared.ConfigPath = tempDir + "/config.toml"
+	defer func() {
+		shared.ConfigPath = originalConfigPath
+	}()
+
+	// Only the production host should ever be hit, even though the URL asks for an attacker host.
+	gock.New("https://cloud.paretosecurity.com").
+		Post("/api/v1/team/enroll").
+		Reply(200).
+		JSON(map[string]string{
+			"auth": "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJ0ZWFtX2lkIjoiMjQyOWM0OWUtMzdiYi00MWJiLTkwNzctNmJiNjIwMmUyNTViIiwic3ViIjoianRAZXhhbXBsZS5jb20iLCJpYXQiOjE3MzY0MTc0MTB9.test",
+		})
+	gock.New("https://cloud.paretosecurity.com").
+		Patch("/api/v1/team/2429c49e-37bb-41bb-9077-6bb6202e255b/device").
+		Reply(200).
+		JSON(map[string]string{"status": "ok"})
+
+	shared.Config.TeamID = ""
+	shared.Config.AuthToken = ""
+	shared.Config.TeamAPI = ""
+	defer func() {
+		shared.Config.TeamID = ""
+		shared.Config.AuthToken = ""
+		shared.Config.TeamAPI = ""
+	}()
+
+	os.Unsetenv(allowHostOverrideEnv)
+
+	err := runLinkCommand("paretosecurity://linkDevice?invite_id=test-invite-123&host=https://attacker.example.com")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://cloud.paretosecurity.com", shared.Config.TeamAPI)
+	assert.True(t, gock.IsDone())
+}
+
+func TestRunLinkCommand_HostOverrideAllowedWhenOptedIn(t *testing.T) {
+	defer gock.Off()
+
+	tempDir := t.TempDir()
+	originalConfigPath := shared.ConfigPath
+	shared.ConfigPath = tempDir + "/config.toml"
+	defer func() {
+		shared.ConfigPath = originalConfigPath
+	}()
+
+	os.Setenv(allowHostOverrideEnv, "1")
+	defer os.Unsetenv(allowHostOverrideEnv)
+
+	gock.New("https://staging.example.com").
+		Post("/api/v1/team/enroll").
+		Reply(200).
+		JSON(map[string]string{
+			"auth": "eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJ0ZWFtX2lkIjoiMjQyOWM0OWUtMzdiYi00MWJiLTkwNzctNmJiNjIwMmUyNTViIiwic3ViIjoianRAZXhhbXBsZS5jb20iLCJpYXQiOjE3MzY0MTc0MTB9.test",
+		})
+	gock.New("https://staging.example.com").
+		Patch("/api/v1/team/2429c49e-37bb-41bb-9077-6bb6202e255b/device").
+		Reply(200).
+		JSON(map[string]string{"status": "ok"})
+
+	shared.Config.TeamID = ""
+	shared.Config.AuthToken = ""
+	shared.Config.TeamAPI = ""
+	defer func() {
+		shared.Config.TeamID = ""
+		shared.Config.AuthToken = ""
+		shared.Config.TeamAPI = ""
+	}()
+
+	err := runLinkCommand("paretosecurity://linkDevice?invite_id=test-invite-123&host=https://staging.example.com")
+	assert.NoError(t, err)
+	assert.Equal(t, "https://staging.example.com", shared.Config.TeamAPI)
+	assert.True(t, gock.IsDone())
 }
 
 func TestRunLinkCommand_RelinkSuccess(t *testing.T) {


### PR DESCRIPTION
The link command accepted an arbitrary host query parameter from
paretosecurity://linkDevice URLs and used it directly as the team
API endpoint, with no validation. A crafted link could redirect
device enrollment and report traffic to an attacker-controlled
server.

Ignore the host override unless PARETO_ALLOW_HOST_OVERRIDE is set;
otherwise always enroll against the production Pareto Cloud API.

Also:
- add tests covering the default-ignored and opted-in paths

Refs https://github.com/teamniteo/pareto/issues/863