### PR TITLE
fix: Enforce GPG signature checks on RPM repo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,6 +188,9 @@ jobs:
       - name: Create RPM repository
         run: mv dist/*.rpm apt/rpm && createrepo_c apt/rpm
 
+      - name: Verify RPM repo enforces signature checks
+        run: grep -qx 'gpgcheck=1' apt/rpm/paretosecurity.repo
+
       - name: Create Arch repository
         continue-on-error: true
         run: |

--- a/apt/rpm/paretosecurity.repo
+++ b/apt/rpm/paretosecurity.repo
@@ -3,5 +3,5 @@ name=paretosecurity-stable
 baseurl=https://pkg.paretosecurity.com/rpm
 enabled=1
 type=rpm
-gpgcheck=0
+gpgcheck=1
 gpgkey=https://pkg.paretosecurity.com/paretosecurity.gpg


### PR DESCRIPTION
The published paretosecurity.repo set gpgcheck=0, so dnf never
verified the RPM's GPG signature even though the installer imports
the Pareto key first and every RPM is properly signed at release
time. A compromised or mispublished repo/CDN/artifact path could
have served an unsigned or maliciously signed package with no
policy check blocking the install.

Set gpgcheck=1 and add a release step that fails if the published
repo file ever reverts to gpgcheck=0.

Refs https://github.com/teamniteo/pareto/issues/864